### PR TITLE
#28: Fix Template Repository Name in New Metadata Repository Checklist Issue Template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-metadata-repository-checklist.yml
+++ b/.github/ISSUE_TEMPLATE/new-metadata-repository-checklist.yml
@@ -21,7 +21,7 @@ body:
     attributes:
       label: 'Steps to follow when creating a new repository before it is ready for work.'
       options:
-        - label: 'I used the `github-template` template repository, and only copied the `development` (default) branch.'
+        - label: 'I used the `github-repository-template` template repository, and only copied the `development` (default) branch.'
         - label: 'I unchecked `General` => `Preserve this repository`.'
         - label: 'I checked `General` => `Allow squash merging` => `default to pull request title`.'
         - label: 'I unchecked `General` => `Allow rebase merging`.'


### PR DESCRIPTION
Resolves #28 for reopening comment [here](https://github.com/atomic-works/github-management/issues/28#issuecomment-1741787781).